### PR TITLE
Use headings for all levels of ToS section hierarchy

### DIFF
--- a/general/TermsOfService.md
+++ b/general/TermsOfService.md
@@ -1,3 +1,5 @@
+## Preface
+
 <!--Plain English:
 By using Gruntwork products and services, you agree to these Terms of Service. You must have a Gruntwork Subscription to use any Gruntwork services.
 -->
@@ -16,37 +18,63 @@ Gruntwork may revise these Terms from time to time. If Gruntwork does revise the
 We've defined some important terms.
 -->
 
-**1.1.** **“Affiliate”** means any person or entity owned or controlled by a party, owning or controlling a party, or under common ownership and control with a party, with “control” meaning the possession, directly or indirectly, of the power to direct or cause the direction of the management and policies of a person, whether through the ownership of voting securities, by contract interest or otherwise. For purposes of this Agreement, the term “Affiliate” does not include your investors or entities controlled by your investors that are not involved in your day-to-day business purpose.
+### 1.1. Affiliate
 
-**1.2.** **“Authorized User”** means your employees, contractors, or Machine Users (as defined below) that are authorized under this Agreement to use the Services on your behalf.
+**“Affiliate”** means any person or entity owned or controlled by a party, owning or controlling a party, or under common ownership and control with a party, with “control” meaning the possession, directly or indirectly, of the power to direct or cause the direction of the management and policies of a person, whether through the ownership of voting securities, by contract interest or otherwise. For purposes of this Agreement, the term “Affiliate” does not include your investors or entities controlled by your investors that are not involved in your day-to-day business purpose.
 
-**1.3.** **“Confidential Information”** means any information or data disclosed by either party that is marked or otherwise designated as confidential or proprietary or that should otherwise be reasonably understood to be confidential in light of the nature of the information and the circumstances surrounding disclosure. However, “Confidential Information” will not include any information which (a) is in the public domain through no fault of receiving party; (b) was properly known to receiving party, without restriction, prior to disclosure by the disclosing party; (c) was properly disclosed to receiving party, without restriction, by another person with the legal authority to do so; or (d) is independently developed by the receiving party without use of or reference to the disclosing party’s Confidential Information.
+### 1.2. Authorized Users
 
-**1.4.** **“Documentation”** means the printed and digital instructions, on-line help files, technical documentation and user manuals made available by Gruntwork for the Services.
+**“Authorized User”** means your employees, contractors, or Machine Users (as defined below) that are authorized under this Agreement to use the Services on your behalf.
 
-**1.5.** **“Machine User”** means a user account set up by an individual human who accepts this Agreement on behalf of the user account, provides a valid email address, and is responsible for its actions. A Machine User is used exclusively for performing automated tasks. Multiple users may direct the actions of a Machine User, but the owner of the Machine User is ultimately responsible for the machine's actions.
+### 1.3. Confidential Information
 
-**1.5.** **“Order Form”** means an order form, quote or other similar document that sets forth the specific Services and pricing therefor (including in relation to overages), permitted number of users, licenses, and subscription term, and that references this Agreement and is mutually executed by the parties.
+**“Confidential Information”** means any information or data disclosed by either party that is marked or otherwise designated as confidential or proprietary or that should otherwise be reasonably understood to be confidential in light of the nature of the information and the circumstances surrounding disclosure. However, “Confidential Information” will not include any information which (a) is in the public domain through no fault of receiving party; (b) was properly known to receiving party, without restriction, prior to disclosure by the disclosing party; (c) was properly disclosed to receiving party, without restriction, by another person with the legal authority to do so; or (d) is independently developed by the receiving party without use of or reference to the disclosing party’s Confidential Information.
 
-**1.6.** **“Team”** means a unique code repository used to manage infrastructure-as-code for a specific group or project within your organization, intended to represent a single team. Despite potential use by multiple groups, each code repository is considered one Team for the purpose of licensing under this Agreement.
+### 1.4. Documentation
+
+**“Documentation”** means the printed and digital instructions, on-line help files, technical documentation and user manuals made available by Gruntwork for the Services.
+
+### 1.5. Machine User
+
+**“Machine User”** means a user account set up by an individual human who accepts this Agreement on behalf of the user account, provides a valid email address, and is responsible for its actions. A Machine User is used exclusively for performing automated tasks. Multiple users may direct the actions of a Machine User, but the owner of the Machine User is ultimately responsible for the machine's actions.
+
+### 1.6. Order Form
+
+**“Order Form”** means an order form, quote or other similar document that sets forth the specific Services and pricing therefor (including in relation to overages), permitted number of users, licenses, and subscription term, and that references this Agreement and is mutually executed by the parties.
+
+### 1.7. Team
+
+**“Team”** means a unique code repository used to manage infrastructure-as-code for a specific group or project within your organization, intended to represent a single team. Despite potential use by multiple groups, each code repository is considered one Team for the purpose of licensing under this Agreement.
 
 ## 2. The Services
+
+### 2.1. Provision of the Services
 
 <!--Plain English:
 Our commitment to you includes these terms and the SLA at https://gruntwork.io/legal/sla.
 -->
 
-**2.1. Provision of the Services.** Subject to the terms and conditions of this Agreement, Gruntwork will make the Services available to Customer pursuant to this Agreement, the license grant set forth in Section 3, the SLA available at https://gruntwork.io/legal/sla and the applicable Order Form.
+Subject to the terms and conditions of this Agreement, Gruntwork will make the Services available to Customer pursuant to this Agreement, the license grant set forth in Section 3, the SLA available at https://gruntwork.io/legal/sla and the applicable Order Form.
 
-**2.2. Customer Responsibilities.**
+### 2.2. Customer Responsibilities
+
+#### 2.2.1 Cooperation
 
 <!--Plain English:
-To provide our services to you, we'll need your cooperation. You also promise not to use our services in an improper way and to take responsibility for the acts of your company's users.
+To provide our services to you, we'll need your cooperation.
 -->
 
-**2.2.1 Cooperation.** Customer acknowledges that Gruntwork’s provision of the Services is dependent on Customer providing all reasonably required cooperation, and Customer will provide all such cooperation in a diligent and timely manner.
+Customer acknowledges that Gruntwork’s provision of the Services is dependent on Customer providing all reasonably required cooperation, and Customer will provide all such cooperation in a diligent and timely manner.
 
-**2.2.2 Responsibility for Use.** Customer will (i) be responsible for all use of the Services under its account, including use by its Authorized Users and Affiliates who have the right to use the Services, provided such Affiliate complies with the Agreement and conditions hereunder (ii) use commercially reasonable efforts to prevent unauthorized access to or use of the Services and notify Gruntwork promptly of any such unauthorized access or use or any other known or suspected breach of security or misuse of the Service and (iii) be responsible for obtaining and maintaining any equipment, software and ancillary services needed to connect to, access or otherwise use the Service, including as set forth in the Documentation. Customer will be solely responsible for its failure to maintain such equipment, software and services, and Gruntwork will have no liability for such failure (including under any service level agreement).
+#### 2.2.2 Responsibility for Use
+
+<!--Plain English:
+You promise not to use our services in an improper way and to take responsibility for the acts of your company's users.
+-->
+
+Customer will (i) be responsible for all use of the Services under its account, including use by its Authorized Users and Affiliates who have the right to use the Services, provided such Affiliate complies with the Agreement and conditions hereunder (ii) use commercially reasonable efforts to prevent unauthorized access to or use of the Services and notify Gruntwork promptly of any such unauthorized access or use or any other known or suspected breach of security or misuse of the Service and (iii) be responsible for obtaining and maintaining any equipment, software and ancillary services needed to connect to, access or otherwise use the Service, including as set forth in the Documentation. Customer will be solely responsible for its failure to maintain such equipment, software and services, and Gruntwork will have no liability for such failure (including under any service level agreement).
+
+### 2.3. Adding/Removing Users and Teams
 
 <!--Plain English:
 Both you and your affiliates can use Gruntwork.
@@ -54,41 +82,61 @@ Both you and your affiliates can use Gruntwork.
 An Authorized User is a human or machine that you designate to use our services.
 -->
 
-**2.3. Adding/Removing Users and Teams.** You are entitled to up to the maximum number of Authorized Users and Teams specified in your most recent Order Form. If you wish to increase your maximum number of Authorized Users or Teams, you must purchase licenses from Gruntwork. When an Authorized User ends their employment or contractual relationship with you, you agree to remove the Authorized User within ten (10) business days.
+You are entitled to up to the maximum number of Authorized Users and Teams specified in your most recent Order Form. If you wish to increase your maximum number of Authorized Users or Teams, you must purchase licenses from Gruntwork. When an Authorized User ends their employment or contractual relationship with you, you agree to remove the Authorized User within ten (10) business days.
+
+### 2.4 Data Security
+
+#### 2.4.1 Security Measures
 
 <!--Plain English:
 Gruntwork has adopted security measures to keep the services and your data safe.
 -->
 
-**2.4 Data Security.**
+Gruntwork has implemented and will maintain appropriate technical and organizational security measures designed to preserve the security and confidentiality of the Services and any Customer Information (defined below) under its control.
 
-**2.4.1 Security Measures.** Gruntwork has implemented and will maintain appropriate technical and organizational security measures designed to preserve the security and confidentiality of the Services and any Customer Information (defined below) under its control.
+#### 2.4.2 Personal Data Commitments
 
-**2.4.2 Personal Data Commitments.** To the extent that, as part of the Services, Gruntwork processes Personal Data on Customer’s behalf, the terms of the Gruntwork Data Processing Agreement (currently located at https://gruntwork.io/legal/dpa), which are incorporated into and form a part of this Agreement, will apply to such processing.
+To the extent that, as part of the Services, Gruntwork processes Personal Data on Customer’s behalf, the terms of the Gruntwork Data Processing Agreement (currently located at https://gruntwork.io/legal/dpa), which are incorporated into and form a part of this Agreement, will apply to such processing.
 
 ## 3. Intellectual Property Rights
 
+### 3.1. Proprietary Rights
+
+As between the parties, Gruntwork exclusively owns all right, title and interest in and to the Services, System Data and Gruntwork’s Confidential Information. “System Data” means data collected by Gruntwork regarding the Gruntwork Product that may be used to generate logs, statistics or reports regarding the performance, availability, usage, integrity or security of the Services.
+
+### 3.2. License Grant
+
 <!--Plain English:
 Your license to our products and services depends on which services you purchase from Gruntwork.
+-->
 
+The scope of your license will depend on the products and features you purchase from Gruntwork as set forth in the applicable Order Form.
+
+#### 3.2.1. License to Subscription Products
+
+<!--Plain English:
 If you purchase a "Subscription Product" (Pipelines, Patcher, Catalog, Runbooks, support services, or access to KodeKloud), these products are provided to you on a subscription basis and you will lose access if you cancel.
+-->
 
+The Subscription Products include Gruntwork Pipelines, Gruntwork Patcher, Gruntwork Catalog, Gruntwork Runbooks, support services, and access to KodeKloud and are provided to you as hosted software, self-hosted software, or a pre-built binary. Subject to the terms and conditions of this Agreement, Gruntwork will make the Subscription Products available to you during the term of your applicable Order Form, and hereby grants you a non-exclusive right to access and use the Subscription Products for your business purposes (the “Subscription License”). No other license rights will apply to the Subscription Products. For the avoidance of doubt, the Post-Termination License (set forth in Section 4.4) does not apply to the Subscription License. Unless explicitly stated otherwise in your Order Form, your access and use of the Services are subject to the Subscription License.
+
+#### 3.2.2 License to Library Products
+
+<!--Plain English:
 If you purchase a "Library Product" (Library), we give you a broad license to the code for use with your own infrastructure, and per [Section 4.4] you can continue using it even if you cancel. But you can't share the code with another company, resell it, publish it as open source, or try to sub-license it.
 -->
 
-**3.1. Proprietary Rights.** As between the parties, Gruntwork exclusively owns all right, title and interest in and to the Services, System Data and Gruntwork’s Confidential Information. “System Data” means data collected by Gruntwork regarding the Gruntwork Product that may be used to generate logs, statistics or reports regarding the performance, availability, usage, integrity or security of the Services.
+The Library Products include Gruntwork Library, which is a collection of infrastructure code created and updated from time to time by Gruntwork, and which is made available via the private git repositories listed at https://www.gruntwork.io/legal/library-repos. Gruntwork hereby grants you a royalty-free, worldwide, non-exclusive, non-transferable (other than as specifically set forth in Section 15 below), non-sublicensable license to use, install, test, execute, perform, and copy the Library Products exclusively for your internal business use, and to create derivative works or otherwise modify the Library Products purely for your internal business purposes (the “Library License”). For the avoidance of doubt, you may not distribute any Library Products to a third-party. Your use of the Library Products is solely for your internal business use only. Additionally, the Library License is granted on a per Authorized User basis, and you must purchase and maintain a valid license for each Authorized User who accesses the Library Products. The Library License is only granted to you if your applicable Order Form explicitly includes reference to a Library Product.
 
-**3.2. License Grant.** The scope of your license will depend on the products and features you purchase from Gruntwork as set forth in the applicable Order Form.
-
-**3.2.1. License to Subscription Products.** The Subscription Products include Gruntwork Pipelines, Gruntwork Patcher, Gruntwork Catalog, Gruntwork Runbooks, support services, and access to KodeKloud and are provided to you as hosted software, self-hosted software, or a pre-built binary. Subject to the terms and conditions of this Agreement, Gruntwork will make the Subscription Products available to you during the term of your applicable Order Form, and hereby grants you a non-exclusive right to access and use the Subscription Products for your business purposes (the “Subscription License”). No other license rights will apply to the Subscription Products. For the avoidance of doubt, the Post-Termination License (set forth in Section 4.4) does not apply to the Subscription License. Unless explicitly stated otherwise in your Order Form, your access and use of the Services are subject to the Subscription License.
-
-**3.2.2 License to Library Products.** The Library Products include Gruntwork Library, which is a collection of infrastructure code created and updated from time to time by Gruntwork, and which is made available via the private git repositories listed at https://www.gruntwork.io/legal/library-repos. Gruntwork hereby grants you a royalty-free, worldwide, non-exclusive, non-transferable (other than as specifically set forth in Section 15 below), non-sublicensable license to use, install, test, execute, perform, and copy the Library Products exclusively for your internal business use, and to create derivative works or otherwise modify the Library Products purely for your internal business purposes (the “Library License”). For the avoidance of doubt, you may not distribute any Library Products to a third-party. Your use of the Library Products is solely for your internal business use only. Additionally, the Library License is granted on a per Authorized User basis, and you must purchase and maintain a valid license for each Authorized User who accesses the Library Products. The Library License is only granted to you if your applicable Order Form explicitly includes reference to a Library Product.
+### 3.4. Professional Services
 
 <!--Plain English:
 We can optionally provide you with Professional Services to help you with the Gruntwork services.
 -->
 
-**3.4. Professional Services.** In connection with providing you the Services, Gruntwork may offer initial configuration assistance, Customer training, migration or other professional services that Gruntwork furnishes to Customer related to the Services (the “Professional Services”). If applicable, Gruntwork will use commercially reasonable efforts to (1) perform Professional Services and (2) deliver any deliverables in conformance with Gruntwork's provision of the Professional Services. Customer will give Gruntwork timely access to customer materials reasonably needed for Professional Services and/or the deliverables, and Gruntwork will use the customer materials only for purposes of providing Professional Services. Except as set forth otherwise and further described in a statement of work (“SOW”), (A) as between the parties, Gruntwork shall solely and exclusively own all right, title, interest in the Professional Services and (B) to the extent Gruntwork creates any work product or code on behalf of Customer in furtherance of the Professional Services (the “Deliverables”), and subject to the restriction set forth in Section 7.2(c), Gruntwork grants Customer a non-exclusive, perpetual license to use the Deliverables created from the Professional Services.
+In connection with providing you the Services, Gruntwork may offer initial configuration assistance, Customer training, migration or other professional services that Gruntwork furnishes to Customer related to the Services (the “Professional Services”). If applicable, Gruntwork will use commercially reasonable efforts to (1) perform Professional Services and (2) deliver any deliverables in conformance with Gruntwork's provision of the Professional Services. Customer will give Gruntwork timely access to customer materials reasonably needed for Professional Services and/or the deliverables, and Gruntwork will use the customer materials only for purposes of providing Professional Services. Except as set forth otherwise and further described in a statement of work (“SOW”), (A) as between the parties, Gruntwork shall solely and exclusively own all right, title, interest in the Professional Services and (B) to the extent Gruntwork creates any work product or code on behalf of Customer in furtherance of the Professional Services (the “Deliverables”), and subject to the restriction set forth in Section 7.2(c), Gruntwork grants Customer a non-exclusive, perpetual license to use the Deliverables created from the Professional Services.
+
+### 3.5 Customer Contributions to Gruntwork
 
 <!--Plain English:
 Any modifications you make to our code in your own code repos are your intellectual property and Gruntwork will not have any rights to it.
@@ -96,15 +144,21 @@ Any modifications you make to our code in your own code repos are your intellect
 However, if you find a bug in our code or see an opportunity for an improvement and you decide to contribute some code back to us via a GitHub pull request, we’ll want to share that code with all our customers, so we’ll own the code you submit. If you don't want us to own the code, just don't contribute it our repos.
 -->
 
-**3.5 Customer Contributions to Gruntwork.** Nothing in this Agreement requires you to contribute to the Services; however, if you choose to contribute any intellectual property via a submission to a Gruntwork source code repository (for example, via a GitHub pull request), Gruntwork will own such contribution (“Gruntwork-Owned Contribution”). You warrant that Gruntwork-Owned Contributions do not include any of your Confidential Information (as defined in Section 7), and you hereby assign to Gruntwork all rights in the Gruntwork-Owned Contribution, including, without limitation, all copyrights, patent rights, trade secret rights, trademark rights, moral rights, and other intellectual property rights to and in the Services in the United States and all other countries, including the right to pursue patents, utility models, or industrial design applications in the United States and all other countries, and will do everything reasonably possible (when requested by Gruntwork, and at Gruntwork’s expense) to carry out in good faith the intent of this clause. Nothing in this Agreement requires you to provide access to Gruntwork to your source code repository, unless otherwise expressly required under the Agreement of a specific Service that you have utilized.
+Nothing in this Agreement requires you to contribute to the Services; however, if you choose to contribute any intellectual property via a submission to a Gruntwork source code repository (for example, via a GitHub pull request), Gruntwork will own such contribution (“Gruntwork-Owned Contribution”). You warrant that Gruntwork-Owned Contributions do not include any of your Confidential Information (as defined in Section 7), and you hereby assign to Gruntwork all rights in the Gruntwork-Owned Contribution, including, without limitation, all copyrights, patent rights, trade secret rights, trademark rights, moral rights, and other intellectual property rights to and in the Services in the United States and all other countries, including the right to pursue patents, utility models, or industrial design applications in the United States and all other countries, and will do everything reasonably possible (when requested by Gruntwork, and at Gruntwork’s expense) to carry out in good faith the intent of this clause. Nothing in this Agreement requires you to provide access to Gruntwork to your source code repository, unless otherwise expressly required under the Agreement of a specific Service that you have utilized.
 
-**3.6. License to Customer Information.** You grant Gruntwork a worldwide, non-exclusive license to host, copy, process, transmit, and display information, data, and other content provided or submitted by you or your Authorized Users to or through the Services (and modification and derivatives thereof) (collectively, “Customer Information”) solely for the purpose of Gruntwork providing the Services to you in accordance with this Agreement.
+### 3.6. License to Customer Information
+
+You grant Gruntwork a worldwide, non-exclusive license to host, copy, process, transmit, and display information, data, and other content provided or submitted by you or your Authorized Users to or through the Services (and modification and derivatives thereof) (collectively, “Customer Information”) solely for the purpose of Gruntwork providing the Services to you in accordance with this Agreement.
+
+### 3.7. Gruntwork Use of Open Source Software
 
 <!--Plain English:
 Some of the code in our library contains open source tools that use a “copyleft” license like GPL (e.g. wget). We won’t modify these tools in such a way that we trigger a “viral” obligation that requires our code (or your derivative works from our code) to be released as GPL. We’ll always comply with Gruntwork’s Open Source Usage Policy when using open source software.
 -->
 
-**3.7. Gruntwork Use of Open Source Software.** You acknowledge that from time to time Gruntwork may utilize third-party software, such as publicly-distributed software (e.g., third-party software commonly known as “free software” or “open source software” subject to one or more third-party license agreements), or other third-party documentation and information in connection with providing the Library Products. Gruntwork may incorporate such third-party software into the Library Products or make use of such third-party software in the Library Products. If the third-party software uses a GPL, LGPL, or MPL license, Gruntwork will ensure the use of that third-party software in the Library Products does not trigger GPL, LGPL, or MPL obligations commonly referred to as “viral” obligations. Gruntwork will at all times use such third-party software only in accordance with Gruntwork’s Open Source Usage Policy located at https://gruntwork.io/open-source-policy, which may be updated from time to time but at all times will meet industry standards.
+You acknowledge that from time to time Gruntwork may utilize third-party software, such as publicly-distributed software (e.g., third-party software commonly known as “free software” or “open source software” subject to one or more third-party license agreements), or other third-party documentation and information in connection with providing the Library Products. Gruntwork may incorporate such third-party software into the Library Products or make use of such third-party software in the Library Products. If the third-party software uses a GPL, LGPL, or MPL license, Gruntwork will ensure the use of that third-party software in the Library Products does not trigger GPL, LGPL, or MPL obligations commonly referred to as “viral” obligations. Gruntwork will at all times use such third-party software only in accordance with Gruntwork’s Open Source Usage Policy located at https://gruntwork.io/open-source-policy, which may be updated from time to time but at all times will meet industry standards.
+
+### 3.8. Your Use of Open Source Software
 
 <!--Plain English:
 Gruntwork has made a commitment not to modify any open source code in a way that triggers a “viral” obligation.
@@ -112,29 +166,39 @@ Gruntwork has made a commitment not to modify any open source code in a way that
 Here, we ask you to do the same. In practice, this means that if you modify our code, you can’t modify any GPL code that we distribute with the code. For example, we use `wget` in many of our bash scripts. If you need to make a change to how we use `wget`, don’t modify `wget` itself because the GPL license on `wget` will then require that all the code that uses `wget` be made GPL as well.
 -->
 
-**3.8. Your Use of Open Source Software.** You also acknowledge that, under the terms of the Library License granted herein, you agree not to distribute the Library Products or any derivative of the Library Products in any way and, as such, acknowledge and agree that you will not “convey” any Library Products or derivative of the Library Products in a manner that would trigger GPL, LGPL, or MPL obligations commonly referred to as “viral” obligations. In the event you produce any derivative work from any portion of the Library Products, or otherwise modify the Library Products, you shall be solely responsible for ensuring that such derivatives or modifications comply with the terms of the licenses to any third-party software incorporated into the Library Products.
+You also acknowledge that, under the terms of the Library License granted herein, you agree not to distribute the Library Products or any derivative of the Library Products in any way and, as such, acknowledge and agree that you will not “convey” any Library Products or derivative of the Library Products in a manner that would trigger GPL, LGPL, or MPL obligations commonly referred to as “viral” obligations. In the event you produce any derivative work from any portion of the Library Products, or otherwise modify the Library Products, you shall be solely responsible for ensuring that such derivatives or modifications comply with the terms of the licenses to any third-party software incorporated into the Library Products.
+
+### 3.9. Feedback
 
 <!--Plain English:
 If you give us a great idea, we get to use it and share it!
 -->
 
-**3.9. Feedback.** You hereby grant Gruntwork a royalty-free, worldwide, transferable, sublicensable, irrevocable, perpetual license to use, reproduce, translate, modify, create derivative works from, distribute, and incorporate into the Services, any suggestions, enhancement requests, recommendations or other feedback provided by you or your Authorized Users relating to Services. Notwithstanding anything stated to the contrary in this Agreement, this irrevocable license will continue after the expiry or termination of this Agreement for any reason.
+You hereby grant Gruntwork a royalty-free, worldwide, transferable, sublicensable, irrevocable, perpetual license to use, reproduce, translate, modify, create derivative works from, distribute, and incorporate into the Services, any suggestions, enhancement requests, recommendations or other feedback provided by you or your Authorized Users relating to Services. Notwithstanding anything stated to the contrary in this Agreement, this irrevocable license will continue after the expiry or termination of this Agreement for any reason.
 
 ## 4. Term and Termination
+
+### 4.1. Term
 
 <!--Plain English:
 Your use of the services requires a subscription. Your subscription will automatically renew for successive terms unless you tell us otherwise at least 15 days before it renews.
 -->
 
-**4.1. Term.** The term of this Agreement will become effective on the date these Terms are accepted by you and continue until your account is terminated as set forth below.. Except as set forth in an Order Form, the term of your Agreement will automatically renew for successive renewal terms equal to the length of the initial term, unless either party provides the other party with written notice of non-renewal at least fifteen (15) days prior to the end of the then-current term (each, a “Renewal Term”).
+The term of this Agreement will become effective on the date these Terms are accepted by you and continue until your account is terminated as set forth below.. Except as set forth in an Order Form, the term of your Agreement will automatically renew for successive renewal terms equal to the length of the initial term, unless either party provides the other party with written notice of non-renewal at least fifteen (15) days prior to the end of the then-current term (each, a “Renewal Term”).
+
+### 4.2. Termination
 
 <!--Plain English:
 If either of us fails to live up to these terms, we have to let the other one know, and if the problem isn’t fixed within 30 days, the agreement between us will terminate. Under certain very specific circumstances, we can suspend or terminate your account immediately.
 -->
 
-**4.2. Termination.** Each party may terminate this Agreement upon written notice to the other party if there are no Order Forms then in effect. Each party may also terminate this Agreement or the applicable Order Form upon written notice in the event (a) the other party commits any material breach of this Agreement or the applicable Order Form and fails to remedy such breach within thirty (30) days after written notice of such breach or (b) subject to applicable law, upon the other party’s liquidation, commencement of dissolution proceedings or assignment of substantially all its assets for the benefit of creditors, or if the other party become the subject of bankruptcy or similar proceeding that is not dismissed within sixty (60) days. Gruntwork may further terminate this Agreement if (a) we, in our sole discretion and in good faith, believe you have breached your warranty set forth in Section 10 or (b) if, in our sole discretion, we believe that you or your Authorized Users’ continued use of the Services creates legal risk for Gruntwork or presents a threat to the security of the Services or other Gruntwork customers.
+Each party may terminate this Agreement upon written notice to the other party if there are no Order Forms then in effect. Each party may also terminate this Agreement or the applicable Order Form upon written notice in the event (a) the other party commits any material breach of this Agreement or the applicable Order Form and fails to remedy such breach within thirty (30) days after written notice of such breach or (b) subject to applicable law, upon the other party’s liquidation, commencement of dissolution proceedings or assignment of substantially all its assets for the benefit of creditors, or if the other party become the subject of bankruptcy or similar proceeding that is not dismissed within sixty (60) days. Gruntwork may further terminate this Agreement if (a) we, in our sole discretion and in good faith, believe you have breached your warranty set forth in Section 10 or (b) if, in our sole discretion, we believe that you or your Authorized Users’ continued use of the Services creates legal risk for Gruntwork or presents a threat to the security of the Services or other Gruntwork customers.
 
-**4.3. Effects of Suspension or Termination.** If, at any time, any of the Services or the Agreement (or any portion hereof) are suspended or terminated for any reason, you will not be entitled to a refund of any amounts paid, to the fullest extent permitted by law. Notwithstanding anything stated to the contrary, all Sections of this Agreement that, either explicitly or by their nature, must remain in effect after termination of the Agreement, shall survive termination .
+### 4.3. Effects of Suspension or Termination
+
+If, at any time, any of the Services or the Agreement (or any portion hereof) are suspended or terminated for any reason, you will not be entitled to a refund of any amounts paid, to the fullest extent permitted by law. Notwithstanding anything stated to the contrary, all Sections of this Agreement that, either explicitly or by their nature, must remain in effect after termination of the Agreement, shall survive termination .
+
+### 4.4. Post-Termination Library License
 
 <!--Plain English:
 If you stick with the annual subscription for at least one year, even if you cancel, you can keep using all the Library Product code you had access to at the time of cancellation at no additional cost.
@@ -142,21 +206,25 @@ If you stick with the annual subscription for at least one year, even if you can
 We recommend that before termination, you clone any Gruntwork repos and update your infrastructure code to remove all references to private Gruntwork repos.
 -->
 
-**4.4. Post-Termination Library License.** If, at any time, all or any portion of the Agreement or your Services are terminated (other than by Gruntwork for cause), the Library License will remain in effect for all of your forks of the Library Products source code repositories as of the termination date. Gruntwork recommends that, prior to the termination date, you fork any Gruntwork source code repositories and update your infrastructure code to remove all references to any private Gruntwork source code repositories. Notwithstanding the foregoing, the Library License set forth in this Section 4.4 is only valid to Customers who have purchased (and paid for) at least one consecutive year of the applicable Library Products from Gruntwork .
+If, at any time, all or any portion of the Agreement or your Services are terminated (other than by Gruntwork for cause), the Library License will remain in effect for all of your forks of the Library Products source code repositories as of the termination date. Gruntwork recommends that, prior to the termination date, you fork any Gruntwork source code repositories and update your infrastructure code to remove all references to any private Gruntwork source code repositories. Notwithstanding the foregoing, the Library License set forth in this Section 4.4 is only valid to Customers who have purchased (and paid for) at least one consecutive year of the applicable Library Products from Gruntwork .
 
 ## 5. Compensation and Invoicing
+
+### 5.1. Billing for Services
+
+If Customer has purchased a subscription or has otherwise agreed to pay any fees in an Order Form, Customer will pay Gruntwork the fees set forth in the applicable Order Form. All fees are quoted and payable in United States dollars, all payment obligations are non-cancelable and, except as expressly set forth herein, all fees paid are non-refundable. If Customer has selected a payment plan and provided its payment information to Gruntwork, then Customer (a) represents and warrants to Gruntwork that such information is true and that Customer is authorized to use the payment instrument, (b) will promptly update its account information with any changes to its payment instrument information, and (c) hereby authorizes Gruntwork (including through its payment processor, in which case Customer hereby agrees to the applicable terms and policies of such payment processor) to bill your payment instrument in advance in accordance with the terms of the applicable payment plan. If Customer is paying the fees set forth in an Order Form by invoice, then all fees are due within thirty (30) days of the date of the invoice. If Customer is overdue on any payment and fails to pay within ten (10) business days of a written notice of your overdue payment, then Gruntwork may assess a late fee and/or suspend Customer’s account until Customer pays the amount Customer is overdue plus the late fee. The late fee will be either 1.5% per month, or the maximum amount allowable by law, whichever is less
 
 <!--Plain English:
 You agree to pay us amounts you owe us. If you’re late with your payments, you’ll owe us a 1.5% late fee and plus any costs to collect from you.
 -->
 
-**5.1. Billing for Services.** If Customer has purchased a subscription or has otherwise agreed to pay any fees in an Order Form, Customer will pay Gruntwork the fees set forth in the applicable Order Form. All fees are quoted and payable in United States dollars, all payment obligations are non-cancelable and, except as expressly set forth herein, all fees paid are non-refundable. If Customer has selected a payment plan and provided its payment information to Gruntwork, then Customer (a) represents and warrants to Gruntwork that such information is true and that Customer is authorized to use the payment instrument, (b) will promptly update its account information with any changes to its payment instrument information, and (c) hereby authorizes Gruntwork (including through its payment processor, in which case Customer hereby agrees to the applicable terms and policies of such payment processor) to bill your payment instrument in advance in accordance with the terms of the applicable payment plan. If Customer is paying the fees set forth in an Order Form by invoice, then all fees are due within thirty (30) days of the date of the invoice. If Customer is overdue on any payment and fails to pay within ten (10) business days of a written notice of your overdue payment, then Gruntwork may assess a late fee and/or suspend Customer’s account until Customer pays the amount Customer is overdue plus the late fee. The late fee will be either 1.5% per month, or the maximum amount allowable by law, whichever is less
+### 5.2. Taxes
+
+All applicable use, sales and other similar taxes and government charges will be payable by Customer. Customer will not withhold any taxes from any amounts due to Gruntwork.
 
 <!--Plain English:
 If it turns out we owe taxes on your purchase, you agree to pay all applicable taxes.
 -->
-
-**5.2. Taxes.** All applicable use, sales and other similar taxes and government charges will be payable by Customer. Customer will not withhold any taxes from any amounts due to Gruntwork.
 
 ## 6. Third-Party Applications
 
@@ -168,13 +236,21 @@ From time to time, Gruntwork may offer to you the ability to access, or the Serv
 
 ## 7. Confidentiality; Restrictions
 
+### 7.1. Confidentiality
+
 <!--Plain English:
-We won’t share any confidential information about you, and you agree not to share any confidential information about us, including our code.  You also agree that you will not use our products and services in any improper manner.
+We won’t share any confidential information about you, and you agree not to share any confidential information about us, including our code.
 -->
 
-**7.1. Confidentiality.** Each party agrees that it will use the Confidential Information of the other party solely in accordance with the provisions of this Agreement and it will not disclose the same directly or indirectly, to any third party without the other party’s prior written consent, except as otherwise permitted hereunder. However, either party may disclose Confidential Information (a) to its employees, officers, directors, attorneys, auditors, financial advisors and other representatives who have a need to know and are legally bound to keep such information confidential by confidentiality obligations consistent with those of this Agreement; and (b) as required by law (in which case the receiving party will provide the disclosing party with prior written notification thereof, will provide the disclosing party with the opportunity to contest such disclosure, and will use its reasonable efforts to minimize such disclosure to the extent permitted by applicable law. Neither party will disclose the terms of this Agreement to any third party, except that either party may confidentially disclose such terms to actual or potential lenders, investors or acquirers. Each party agrees to exercise due care in protecting the Confidential Information from unauthorized use and disclosure. In the event of actual or threatened breach of the provisions of this Section 7, the non-breaching party will be entitled to seek immediate injunctive and other equitable relief, without waiving any other rights or remedies available to it. Each party will promptly notify the other in writing if it becomes aware of any violations of the confidentiality obligations set forth in this Agreement.
+Each party agrees that it will use the Confidential Information of the other party solely in accordance with the provisions of this Agreement and it will not disclose the same directly or indirectly, to any third party without the other party’s prior written consent, except as otherwise permitted hereunder. However, either party may disclose Confidential Information (a) to its employees, officers, directors, attorneys, auditors, financial advisors and other representatives who have a need to know and are legally bound to keep such information confidential by confidentiality obligations consistent with those of this Agreement; and (b) as required by law (in which case the receiving party will provide the disclosing party with prior written notification thereof, will provide the disclosing party with the opportunity to contest such disclosure, and will use its reasonable efforts to minimize such disclosure to the extent permitted by applicable law. Neither party will disclose the terms of this Agreement to any third party, except that either party may confidentially disclose such terms to actual or potential lenders, investors or acquirers. Each party agrees to exercise due care in protecting the Confidential Information from unauthorized use and disclosure. In the event of actual or threatened breach of the provisions of this Section 7, the non-breaching party will be entitled to seek immediate injunctive and other equitable relief, without waiving any other rights or remedies available to it. Each party will promptly notify the other in writing if it becomes aware of any violations of the confidentiality obligations set forth in this Agreement.
 
-**7.2. Technology Restrictions.** Customer will not directly or indirectly: (a) reverse engineer, decompile, disassemble, modify, create derivative works of or otherwise create, attempt to create or derive, or permit or assist any third party to create or derive, the source code underlying the Subscription Products; (b) attempt to probe, scan or test the vulnerability of the Subscription Products, breach the security or authentication measures of the Subscription Products without proper authorization or wilfully render any part of the Subscription Products unusable; (c) use or access the Services (including any Deliverables) to develop a product or service that is competitive with Gruntwork’s products or engage in competitive analysis or benchmarking; (d) transfer, distribute, resell, lease, license, or assign the Services or otherwise offer the Services on a standalone basis; or (e) otherwise use the Services in violation of applicable law (including any export law) or outside the scope expressly permitted hereunder and in the applicable Order Form.
+### 7.2. Technology Restrictions
+
+<!--Plain English:
+You agree that you will not use our products and services in any improper manner.
+-->
+
+Customer will not directly or indirectly: (a) reverse engineer, decompile, disassemble, modify, create derivative works of or otherwise create, attempt to create or derive, or permit or assist any third party to create or derive, the source code underlying the Subscription Products; (b) attempt to probe, scan or test the vulnerability of the Subscription Products, breach the security or authentication measures of the Subscription Products without proper authorization or wilfully render any part of the Subscription Products unusable; (c) use or access the Services (including any Deliverables) to develop a product or service that is competitive with Gruntwork’s products or engage in competitive analysis or benchmarking; (d) transfer, distribute, resell, lease, license, or assign the Services or otherwise offer the Services on a standalone basis; or (e) otherwise use the Services in violation of applicable law (including any export law) or outside the scope expressly permitted hereunder and in the applicable Order Form.
 
 ## 8. Limited Liability
 
@@ -194,17 +270,21 @@ You will defend, indemnify, and hold harmless Gruntwork and its Affiliates and t
 
 ## 10. Warranties and Disclaimers
 
+### 10.1. Customer Warranties
+
 <!--Plain English:
 You are stating to us that you can enter into this agreement and that you are not violating any other agreements or the law by doing so.
 -->
 
-**10.1. Customer Warranties.** You hereby represent and warrant to Gruntwork as follows: (a) you have the authority to enter into this Agreement and to bind the entity you have listed to the this Agreement, and that this Agreement constitutes your and its legal, valid, binding and enforceable agreement; and (b) execution and performance of this Agreement (i) does not breach any agreement of yours or the entity’s with any third party, or any duty arising in law or equity, (ii) does not violate any law, rule or regulation applicable to you or the entity, and (iii) are within your and its powers.
+You hereby represent and warrant to Gruntwork as follows: (a) you have the authority to enter into this Agreement and to bind the entity you have listed to the this Agreement, and that this Agreement constitutes your and its legal, valid, binding and enforceable agreement; and (b) execution and performance of this Agreement (i) does not breach any agreement of yours or the entity’s with any third party, or any duty arising in law or equity, (ii) does not violate any law, rule or regulation applicable to you or the entity, and (iii) are within your and its powers.
+
+### 10.2. Disclaimers
 
 <!--Plain English:
 We do not provide any warranties to you.
 -->
 
-**10.2. Disclaimers.** GRUNTWORK DISCLAIMS ALL WARRANTIES WHATSOEVER WITH RESPECT TO THE SERVICES, EITHER EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, ALL IMPLIED WARRANTIES OF MERCHANTABILITY, QUALITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND WARRANTIES ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE. WITHOUT LIMITATION TO THE FOREGOING, GRUNTWORK PROVIDES NO WARRANTY OR UNDERTAKING, AND MAKES NO REPRESENTATION OF ANY KIND, WHETHER EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, THAT THE SERVICES WILL MEET YOUR REQUIREMENTS, MEET ANY PERFORMANCE OR RELIABILITY STANDARDS, OR BE ERROR FREE. IN ADDITION, GRUNTWORK MAKES NO REPRESENTATION OR WARRANTIES REGARDING ITS COMPLIANCE WITH THE CENTER FOR INTERNET SECURITY AWS FOUNDATIONS BENCHMARK NOR DOES IT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY THIRD PARTY APPLICATIONS (OR THE CONTENT THEREOF), OR ANY OTHER PRODUCT OR SERVICE ADVERTISED, PROMOTED OR OFFERED BY A THIRD PARTY ON OR THROUGH THE SERVICES OR ANY HYPERLINKED WEBSITE, AND GRUNTWORK IS NOT RESPONSIBLE OR LIABLE FOR ANY TRANSACTION BETWEEN YOU AND THIRD PARTY PROVIDERS OF THE FOREGOING. NO ADVICE OR INFORMATION WHETHER ORAL OR IN WRITING OBTAINED BY YOU FROM GRUNTWORK SHALL CREATE ANY WARRANTY ON BEHALF OF GRUNTWORK. THIS SECTION APPLIES TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.
+GRUNTWORK DISCLAIMS ALL WARRANTIES WHATSOEVER WITH RESPECT TO THE SERVICES, EITHER EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, ALL IMPLIED WARRANTIES OF MERCHANTABILITY, QUALITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT AND WARRANTIES ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE. WITHOUT LIMITATION TO THE FOREGOING, GRUNTWORK PROVIDES NO WARRANTY OR UNDERTAKING, AND MAKES NO REPRESENTATION OF ANY KIND, WHETHER EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, THAT THE SERVICES WILL MEET YOUR REQUIREMENTS, MEET ANY PERFORMANCE OR RELIABILITY STANDARDS, OR BE ERROR FREE. IN ADDITION, GRUNTWORK MAKES NO REPRESENTATION OR WARRANTIES REGARDING ITS COMPLIANCE WITH THE CENTER FOR INTERNET SECURITY AWS FOUNDATIONS BENCHMARK NOR DOES IT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY THIRD PARTY APPLICATIONS (OR THE CONTENT THEREOF), OR ANY OTHER PRODUCT OR SERVICE ADVERTISED, PROMOTED OR OFFERED BY A THIRD PARTY ON OR THROUGH THE SERVICES OR ANY HYPERLINKED WEBSITE, AND GRUNTWORK IS NOT RESPONSIBLE OR LIABLE FOR ANY TRANSACTION BETWEEN YOU AND THIRD PARTY PROVIDERS OF THE FOREGOING. NO ADVICE OR INFORMATION WHETHER ORAL OR IN WRITING OBTAINED BY YOU FROM GRUNTWORK SHALL CREATE ANY WARRANTY ON BEHALF OF GRUNTWORK. THIS SECTION APPLIES TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW.
 
 ## 11. Export Control
 


### PR DESCRIPTION
This switches all numbered sections of the document to use headings of the appropriate level to their hierarchy in the document. Previously, many sections merely used bold text to denote numbered sections. This change has the following benefits:

1. The resulting document is more semantically structured, and as such will also render a proper TOC in Markdown viewers which support it.
2. The headings will support deep links in Markdown viewers which support it, as well as the Gruntwork marketing website.
3. The "plain english" translations now fit neatly within the corresponding section of the document, rather than preceding it. This makes the relative position of those translations consistent across all sections, and allows them to precede the legalese (which appears preferable) while retaining the proper semantic association.
4. Copying content from the Markdown document into the Gruntwork marketing website CMS is substantially easier and more clear, as the level of the heading is clearly encoded in the copied text, and both the legalese and plain english for each section come together when copied as a block.

This change also corrects the numbering of the definitions section, which had a repeat entry.