### PR TITLE
Clarify the initial and renewal term for historical customers

### DIFF
--- a/general/TermsOfService.md
+++ b/general/TermsOfService.md
@@ -224,7 +224,7 @@ Note that prior to May 2, 2024, these terms of service specified an initial and 
 
 The term of this Agreement will become effective on the date these Terms are accepted by you and continue until your account is terminated as set forth below.. Except as set forth in an Order Form, the term of your Agreement will automatically renew for successive renewal terms equal to the length of the initial term, unless either party provides the other party with written notice of non-renewal at least fifteen (15) days prior to the end of the then-current term (each, a “Renewal Term”).
 
-Notwithstanding the foregoing, except as set forth in an Order Form, for customers who purchased Gruntwork on or before May 2, 2024, the initial term length and Renewal Term is twelve (12) months. 
+Notwithstanding the foregoing, except as set forth in an Order Form, for customers who entered into an Agreement with Gruntwork on or before May 2, 2024, the initial term length of such Agreement and each Renewal Term thereof is twelve (12) months. 
 
 ### 4.2. Termination
 

--- a/general/TermsOfService.md
+++ b/general/TermsOfService.md
@@ -218,9 +218,13 @@ You hereby grant Gruntwork a royalty-free, worldwide, transferable, sublicensabl
 
 <!--Plain English:
 Your use of the services requires a subscription. Your subscription will automatically renew for successive terms unless you tell us otherwise at least 15 days before it renews.
+
+Note that prior to May 2, 2024, these terms of service specified an initial and renewal term of 12 months.
 -->
 
 The term of this Agreement will become effective on the date these Terms are accepted by you and continue until your account is terminated as set forth below.. Except as set forth in an Order Form, the term of your Agreement will automatically renew for successive renewal terms equal to the length of the initial term, unless either party provides the other party with written notice of non-renewal at least fifteen (15) days prior to the end of the then-current term (each, a “Renewal Term”).
+
+Notwithstanding the foregoing, except as set forth in an Order Form, for customers who purchased Gruntwork on or before May 2, 2024, the initial term length and Renewal Term is twelve (12) months. 
 
 ### 4.2. Termination
 


### PR DESCRIPTION
Prior to May 2, 2024, the terms of service defaulted to 12 months for both the initial term and renewal term. In our updated terms of service, we defer to the Order Form, however many customers originally signed with Order Forms that did not specify a term, so the update made it unclear what term they had previously committed to.

This update makes the term length explicit.