### PR TITLE
Improve layout of legal terms on website

### DIFF
--- a/general/TermsOfService.md
+++ b/general/TermsOfService.md
@@ -1,6 +1,6 @@
 ---
 title: Terms of Service
-subheader: This page outlines the terms of service and use of Gruntwork’s products and services.
+header: This page outlines the terms of service and use of Gruntwork’s products and services.
 description: It’s important to understand these Terms of Service, as they define your rights and our rights in our relationship. But legalese is not always easy to understand, so we’ve provided “plain English” summaries on the left side of the page to help you understand the official legal language on the right side of the page. Remember that we’re providing you these summaries for informational purposes only. Our actual Terms are the ones on the right under "Legalese" and will apply if we ever need to work through any issues.
 ---
 

--- a/general/TermsOfService.md
+++ b/general/TermsOfService.md
@@ -1,3 +1,9 @@
+---
+title: Terms of Service
+subheader: This page outlines the terms of service and use of Gruntwork’s products and services.
+description: It’s important to understand these Terms of Service, as they define your rights and our rights in our relationship. But legalese is not always easy to understand, so we’ve provided “plain English” summaries on the left side of the page to help you understand the official legal language on the right side of the page. Remember that we’re providing you these summaries for informational purposes only. Our actual Terms are the ones on the right under "Legalese" and will apply if we ever need to work through any issues.
+---
+
 ## Preface
 
 <!--Plain English:

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "axios": "^1.9.0",
         "glob": "^11.0.2",
+        "gray-matter": "^4.0.3",
         "markdown-it": "^14.1.0",
         "webflow-api": "^3.1.1"
       }
@@ -538,6 +539,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -561,6 +575,18 @@
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -695,6 +721,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -786,6 +827,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -822,6 +872,37 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
       "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
@@ -1153,6 +1234,19 @@
         }
       ]
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -1263,6 +1357,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1357,6 +1457,15 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/tr46": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "axios": "^1.9.0",
     "glob": "^11.0.2",
+    "gray-matter": "^4.0.3",
     "markdown-it": "^14.1.0",
     "webflow-api": "^3.1.1"
   }

--- a/scripts/sync-legal-pages.js
+++ b/scripts/sync-legal-pages.js
@@ -286,6 +286,26 @@ async function syncItem(repoPath, mdContent, htmlContent, title, existingItemsMa
   }
 }
 
+// Good for debugging; write the HTML to a file for review
+function writeHtmlToFile(filePath, htmlContent) {
+  const htmlOutputPath = path.join('scripts', 'output', path.dirname(filePath), `${path.basename(filePath, '.md')}.html`);
+  debugLog(`Writing HTML output to: ${htmlOutputPath}`);
+
+  // Read header and footer templates
+  const headerContent = fs.readFileSync(path.join('scripts', 'input', 'header.html'), 'utf8');
+  const footerContent = fs.readFileSync(path.join('scripts', 'input', 'footer.html'), 'utf8');
+  
+  // Combine header, content and footer
+  const fullHtmlContent = headerContent + htmlContent + footerContent;
+  
+  // Ensure the output directory exists
+  fs.mkdirSync(path.dirname(htmlOutputPath), { recursive: true });
+  
+  // Write the HTML content to file
+  fs.writeFileSync(htmlOutputPath, fullHtmlContent);
+  debugLog(`Successfully wrote HTML to ${htmlOutputPath}`);
+}
+
 // Main sync function
 async function syncWebflow() {
   debugLog('Starting Webflow sync process');
@@ -330,25 +350,9 @@ async function syncWebflow() {
         const title = extractTitle(filePath);
         const repoPath = filePath; // The path relative to the repo root
 
-        // Write HTML content to disk for debugging/review
-        const htmlOutputPath = path.join('scripts', 'output', path.dirname(filePath), `${path.basename(filePath, '.md')}.html`);
-        debugLog(`Writing HTML output to: ${htmlOutputPath}`);
+        writeHtmlToFile(filePath, htmlContent);
 
-        // Read header and footer templates
-        const headerContent = fs.readFileSync(path.join('scripts', 'input', 'header.html'), 'utf8');
-        const footerContent = fs.readFileSync(path.join('scripts', 'input', 'footer.html'), 'utf8');
-        
-        // Combine header, content and footer
-        const fullHtmlContent = headerContent + htmlContent + footerContent;
-        
-        // Ensure the output directory exists
-        fs.mkdirSync(path.dirname(htmlOutputPath), { recursive: true });
-        
-        // Write the HTML content to file
-        fs.writeFileSync(htmlOutputPath, fullHtmlContent);
-        debugLog(`Successfully wrote HTML to ${htmlOutputPath}`);
-
-        debugLog(`Syncing item with title: "${title}", path: "${repoPath}"`);
+        //debugLog(`Syncing item with title: "${title}", path: "${repoPath}"`);
         //await syncItem(repoPath, markdownContent, htmlContent, title, existingItemsMap);
 
       } catch (fileProcessingError) {

--- a/scripts/sync-legal-pages.js
+++ b/scripts/sync-legal-pages.js
@@ -87,13 +87,13 @@ function generateHtmlLayout(sections, frontmatter) {
   let html = '<div class="legal-frontmatter" style="margin-bottom: 2.5em;">';
   if (frontmatter) {
     if (frontmatter.title) {
-      html += `<h1 class="heading" style="margin-bottom: 0.2em;">${frontmatter.title}</h1>`;
+      html += `<h1 class="heading" style="font-size: 3em; margin-bottom: 0.5em;">${frontmatter.title}</h1>`;
     }
     if (frontmatter.header) {
-      html += `<div style="font-size: 1.2em; font-weight: 500; margin-bottom: 0.2em; color: #ccc;">${frontmatter.header}</div>`;
+      html += `<div style="font-size: 1.2em; font-weight: 500; margin-bottom: 1em; color: #ccc;">${frontmatter.header}</div>`;
     }
     if (frontmatter.subheader) {
-      html += `<div style="font-size: 1.1em; font-weight: 500; margin-bottom: 0.2em; color: #bbb;">${frontmatter.subheader}</div>`;
+      html += `<div style="font-size: 1.1em; font-weight: 500; margin-bottom: 0.5em; color: #bbb;">${frontmatter.subheader}</div>`;
     }
     if (frontmatter.description) {
       html += `<div style="font-size: 1em; color: #aaa; margin-bottom: 0.5em;">${frontmatter.description}</div>`;
@@ -316,6 +316,7 @@ async function syncItem(repoPath, mdContent, htmlContent, title, existingItemsMa
 }
 
 // Good for debugging; write the HTML to a file for review
+// Expects a header.html and footer.html in the input directory; the body of each page is rendered between the header.html and footer.html.
 function writeHtmlToFile(filePath, htmlContent, frontmatter) {
   const htmlOutputPath = path.join('scripts', 'output', path.dirname(filePath), `${path.basename(filePath, '.md')}.html`);
   debugLog(`Writing HTML output to: ${htmlOutputPath}`);
@@ -404,8 +405,8 @@ async function syncWebflow() {
 
         writeHtmlToFile(filePath, htmlContent, frontmatter);
 
-        //debugLog(`Syncing item with title: "${title}", path: "${repoPath}"`);
-        //await syncItem(repoPath, markdownContent, htmlContent, title, existingItemsMap);
+        debugLog(`Syncing item with title: "${title}", path: "${repoPath}"`);
+        await syncItem(repoPath, markdownContent, htmlContent, title, existingItemsMap);
 
       } catch (fileProcessingError) {
         console.error(`Error processing file ${filePath}:`, fileProcessingError.message);

--- a/scripts/sync-legal-pages.js
+++ b/scripts/sync-legal-pages.js
@@ -380,8 +380,6 @@ async function syncWebflow() {
         const title = extractTitle(filePath);
         const repoPath = filePath; // The path relative to the repo root
 
-        writeHtmlToFile(filePath, htmlContent, frontmatter);
-
         debugLog(`Syncing item with title: "${title}", path: "${repoPath}"`);
         await syncItem(repoPath, markdownContent, htmlContent, title, existingItemsMap);
 

--- a/scripts/sync-legal-pages.js
+++ b/scripts/sync-legal-pages.js
@@ -325,30 +325,7 @@ function writeHtmlToFile(filePath, htmlContent, frontmatter) {
   let headerContent = fs.readFileSync(path.join('scripts', 'input', 'header.html'), 'utf8');
   const footerContent = fs.readFileSync(path.join('scripts', 'input', 'footer.html'), 'utf8');
 
-  // Remove the <h1 class="heading">...</h1> from the header if frontmatter.title is present
-  if (frontmatter && frontmatter.title) {
-    headerContent = headerContent.replace(/<h1 class=\"heading\">[\s\S]*?<\/h1>/, '');
-  }
-
-  // Insert the legal sections into the correct container after the heading
-  const container2Regex = /(<div class="w-layout-blockcontainer container-2 w-container">)([\s\S]*?<h1 class="heading">[\s\S]*?<\/h1>)/;
-  let fullHtmlContent;
-  if (container2Regex.test(headerContent)) {
-    // If the container and heading are present, insert after the heading
-    fullHtmlContent = headerContent.replace(
-      /(<div class="w-layout-blockcontainer container-2 w-container">[\s\S]*?<h1 class="heading">[\s\S]*?<\/h1>)/,
-      `$1${htmlContent}`
-    ) + footerContent;
-  } else if (headerContent.includes('<div class="w-layout-blockcontainer container-2 w-container">')) {
-    // If only the container is present, insert heading and content
-    fullHtmlContent = headerContent.replace(
-      /(<div class="w-layout-blockcontainer container-2 w-container">)/,
-      `$1${htmlContent}`
-    ) + footerContent;
-  } else {
-    // Fallback: append the container, heading, and content at the end
-    fullHtmlContent = headerContent + `<div class="w-layout-blockcontainer container-2 w-container">${htmlContent}</div>` + footerContent;
-  }
+  fullHtmlContent = headerContent + htmlContent + footerContent;
 
   // Ensure the output directory exists
   fs.mkdirSync(path.dirname(htmlOutputPath), { recursive: true });


### PR DESCRIPTION
- Renders plain English on the side
- Renders frontmatter at the top
- Cleaner formatting is still needed, but core structure should be there!

NOTE: This introduces a new frontmatter standard for all legal docs:

- `title`: The title of the document
- `header`: A header on the page describing the purpose of the document
- `subheader`: A subheader describing more detail
- `description`: A detailed description of what the document is

If we merge this change, we should plan on adding at least `title` to all current legal docs.